### PR TITLE
Fix O and S rules

### DIFF
--- a/Assets/exoplanets.cs
+++ b/Assets/exoplanets.cs
@@ -218,10 +218,10 @@ public class exoplanets : MonoBehaviour
                 targetDigit = (targetDigit + bomb.GetSerialNumberNumbers().ToArray()[1]) % 10;
                 break;
             case "O":
-                if (targetPlanet == Array.IndexOf(planetSpeeds, planetSpeeds.Max()))
-                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Min());
+                if (targetPlanet == Array.IndexOf(planetSpeeds, planetSpeeds.Min()))
+                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Max());
                 else
-                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Where(x => x < planetSpeeds[targetPlanet]).Min());
+                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Where(x => x < planetSpeeds[targetPlanet]).Max());
                 break;
             case "P":
                 targetPlanet = targetPlanet == 0 ? 2 : 0;
@@ -233,10 +233,10 @@ public class exoplanets : MonoBehaviour
                 targetDigit = (targetDigit + 5) % 10;
                 break;
             case "S":
-                if (targetPlanet == Array.IndexOf(planetSpeeds, planetSpeeds.Min()))
-                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Max());
+                if (targetPlanet == Array.IndexOf(planetSpeeds, planetSpeeds.Max()))
+                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Min());
                 else
-                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Where(x => x > planetSpeeds[targetPlanet]).Max());
+                    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Where(x => x > planetSpeeds[targetPlanet]).Min());
                 break;
             case "T":
                 targetDigit = (targetDigit + bomb.GetSerialNumberNumbers().Last()) % 10;


### PR DESCRIPTION
**Changes:**
- Update O and S rules to match logic in the [manual page](https://ktane.timwi.de/HTML/Exoplanets.html)

**Summary:**  
As of the latest update, it seems that the O and S rules are still inconsistent with the manual, and the "wrap-around" edge case is implemented incorrectly causing the module to short-circuit while loading.

**Explanation**:  

<details>
<summary>Core rule issue</summary>
The first part of rule S is described as "Target planet is the fastest-orbiting planet that orbits slower than the current target planet."

```cs
targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Where(x => x > planetSpeeds[targetPlanet]).Max());
```

This `Where` part implements the "orbits slower than the current target planet" part correctly. Since `planetSpeeds` is actually describing the period of rotation for the planets, then anything with a greater period is slower.
```cs
planetSpeeds.Where(x => x > planetSpeeds[targetPlanet])
```

However the `.Max()` call is incorrect, because a larger period means slower planets. So this picks the slowest speed from those planets slower than the current target planet. Rule O has a similar issue.
</details>

<details>
<summary>Edge case issue</summary>
The edge case for rule S is also incorrect, so that it essentially does "if the current target planet is the fastest-orbiting planet (min period), make the slowest-orbiting planet (max period) the target planet" instead of the intended rule of "If the current target planet is the slowest-orbiting planet, the target planet is the fastest-orbiting planet."

```cs
if (targetPlanet == Array.IndexOf(planetSpeeds, planetSpeeds.Min()))
    targetPlanet = Array.IndexOf(planetSpeeds, planetSpeeds.Max());
```

The end result is that rule S always picks the slowest planet, and fails if we apply rule S when the current target planet is the slowest planet. Here's some logs of that:
```
The inner planet has an angular velocity of 10.
The inner planet is small.
The middle planet has an angular velocity of 5.
The middle planet is large.
The outer planet has an angular velocity of 20.
The outer planet is medium.
The outer planet is orbiting counterclockwise, so it is the initial target planet.
The initial target digit is 0.
The star is rotating counterclockwise and there are 4 batteries.
Using rule S.
<end of logs>
```

In this case, the bomb still loads correctly, and I would guess that the result in this of this would be that the initial target parameters end up being the accepted solution (not familiar with how KTANE deals with mod exceptions).

And of course, a similar issue applies for rule O again.
</details>

**Testing:**
Generated a few bombs and checked the logs to make sure they make sense given my understanding above.

<details>
<summary>Here's a log with rule O looping around correctly:</summary>

```
The inner planet has an angular velocity of 40.
The inner planet is large.
The middle planet has an angular velocity of 5.
The middle planet is small.
The outer planet has an angular velocity of 20.
The outer planet is medium.
The middle planet is orbiting clockwise, so it is the initial target planet.
The initial target digit is 7.
The star is rotating clockwise and there are 2 batteries.
Using rule O.
The target planet is now the inner planet.
Moving inward...
Using rule C.
The target planet is now the outer planet.
Moving inward...
Using rule W.
The target digit is now 1.
The final solution is to press the outer planet on a 1.
```
</details>